### PR TITLE
Added the Worker Pool and removed mutex

### DIFF
--- a/memoria.go
+++ b/memoria.go
@@ -400,7 +400,9 @@ func (m *Memoria) BulkWrite(pairs map[string][]byte, numWorkers int) []WriteResu
 
 	// Worker pool
 	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for task := range workChan {
 				err := m.Write(task.key, task.value)
 				resultChan <- WriteResult{

--- a/test/memoria_test.go
+++ b/test/memoria_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	memoria "github.com/IMGIITRoorkee/Memoria_Simple"
@@ -75,6 +76,80 @@ func TestMemoriaWriteRead(t *testing.T) {
 
 			if !bytes.Equal(got, tt.value) {
 				t.Errorf("Read() got = %v, want %v", got, tt.value)
+			}
+		})
+	}
+}
+
+func TestMemoriaWriteReadString(t1 *testing.T) {
+
+	// Create temporary directory for tests
+	tempDir1, err1 := os.MkdirTemp("", "memoria-test-*")
+	if err1 != nil {
+		t1.Fatalf("Failed to create temp dir: %v", err1)
+	}
+	defer os.RemoveAll(tempDir1)
+
+	m := memoria.New(memoria.Options{
+		Basedir:      tempDir1,
+		MaxCacheSize: 1024,
+	})
+
+	tests := []struct {
+		name    string
+		key     string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "Simple write and read (String Wrapper)",
+			key:     "test1",
+			value:   string("Hello World!"),
+			wantErr: false,
+		},
+		{
+			name:    "Empty key",
+			key:     "",
+			value:   string("test"),
+			wantErr: true,
+		},
+		{
+			name:    "Empty value",
+			key:     "test2",
+			value:   string(""),
+			wantErr: false,
+		},
+		{
+			name:    "Large value",
+			key:     "test3",
+			value:   strings.Repeat("a", 1000),
+			wantErr: false,
+		},
+	}
+
+	for _, tt1 := range tests {
+		t1.Run(tt1.name, func(t1 *testing.T) {
+
+			// Test WriteString
+			err1 := m.WriteString(tt1.key, tt1.value)
+			if (err1 != nil) != tt1.wantErr {
+				t1.Errorf("Write() error = %v, wantErr %v", err1, tt1.wantErr)
+				return
+			}
+
+			if tt1.wantErr {
+				return
+			}
+
+			// Test ReadString
+			got1, err1 := m.ReadString(tt1.key)
+			if err1 != nil {
+				t1.Errorf("Read() error = %v", err1)
+				return
+			}
+
+			if got1 != tt1.value {
+				t1.Errorf("Read() got = %v, want %v", got1, tt1.value)
 			}
 		})
 	}


### PR DESCRIPTION
### **_Implement Concurrent Bulk Write Operations using Go Routines_**
**_Closes #20_** 

**Type of Change**
- [x] Modification

**Description of Change**

Within the BulkWrite method that I'd added in my previous commit ( #43 ), I've removed the mutex and introduced a worker pool as instructed. 

**Implementation Details**

The method BulkWrite , takes key-value pairs and number of workers as input and writes them concurrently and gives Writeresults as output, using multiple goroutines. The task uses a worker pool, where a fixed number of worker goroutines are used to process tasks (writing key-value pairs). This helps limit the concurrency, preventing the system from becoming overwhelmed by too many goroutines. And also, the previously used mutex (locking and unlocking) is also removed as it was redundant.